### PR TITLE
Add ability to pass in a protocol stream to proxy function

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,9 @@ function createProxyStream (key, opts) {
     }
   }
 
-  function proxy (otherStream) {
-    const otherProtocol = protocol(opts)
+  function proxy (otherStream, proxyOpts) {
+    if (!proxyOpts) proxyOpts = {}
+    const otherProtocol = proxyOpts.stream || protocol(opts)
     const otherFeed = otherProtocol.feed(key)
 
     proxies.push(otherFeed)


### PR DESCRIPTION
I needed to be able to pass in a hypercore-protocol stream to the proxy() function (instead of letting the proxy create the stream) to make it work with discovery-swarm.

eg.

```js
const sw = discoverySwarm(swarmDefaults({
  live: true,
  hash: false,
  stream: () => protocol({live: true}),
  connect: (connection, swarmStream) => {
    proxy(swarmStream, {stream: connection})
  }
}))
```

I need to do it this way because discovery-swarm needs to listen for the 'handshake' event. Otherwise, it doesn't get it and it times out.